### PR TITLE
Rename the gem to chef-sugar-ng.

### DIFF
--- a/chef-sugar-ng.gemspec
+++ b/chef-sugar-ng.gemspec
@@ -4,9 +4,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'chef/sugar/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'chef-sugar'
+  spec.name          = 'chef-sugar-ng'
   spec.version       = Chef::Sugar::VERSION
-  spec.authors       = ['Seth Vargo']
+  spec.authors       = ['Chef Software, Inc.']
   spec.email         = ['sethvargo@gmail.com']
   spec.description   = 'A series of helpful sugar of the Chef core and ' \
                        'other resources to make a cleaner, more lean recipe ' \
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
                        'make working with Chef recipes awesome.'
   spec.homepage      = 'https://github.com/sethvargo/chef-sugar'
   spec.license       = 'Apache 2.0'
+
 
   spec.required_ruby_version = '>= 2.2.2'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,6 @@
 name             'chef-sugar'
-maintainer       'Seth Vargo'
-maintainer_email 'sethvargo@gmail.com'
+maintainer       'Chef Software, Inc'
+maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Installs chef-sugar. Please see the chef-sugar ' \
                  'Ruby gem for more information.'
@@ -11,14 +11,14 @@ recipe DSL, enforce DRY principles, and make writing Chef recipes an awesome and
 fun experience!
 
 For the most up-to-date information and documentation, please visit the [Chef
-Sugar project page on GitHub](https://github.com/sethvargo/chef-sugar).
+Sugar project page on GitHub](https://github.com/chef/chef-sugar).
 EOH
 
 require          File.expand_path('../lib/chef/sugar/version', __FILE__)
 version          Chef::Sugar::VERSION
 
 supports     'any'
-issues_url   'https://github.com/sethvargo/chef-sugar/issues'
-source_url   'https://github.com/sethvargo/chef-sugar'
+issues_url   'https://github.com/chef/chef-sugar/issues'
+source_url   'https://github.com/chef/chef-sugar'
 chef_version '>= 13.0'
-gem          'chef-sugar'
+gem          'chef-sugar-ng'


### PR DESCRIPTION
The namespace and cookbook remain the same.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>