### PR TITLE
Bump version to 5.0.2

### DIFF
--- a/lib/chef/sugar/version.rb
+++ b/lib/chef/sugar/version.rb
@@ -16,6 +16,6 @@
 
 class Chef
   module Sugar
-    VERSION = '5.0.1'
+    VERSION = '5.0.2'
   end
 end


### PR DESCRIPTION
Updates for the gem rename to chef-sugar-ng.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
