### PR TITLE
Deprecate chef-sugar node API

### DIFF
--- a/lib/chef/sugar/deprecation.rb
+++ b/lib/chef/sugar/deprecation.rb
@@ -1,0 +1,45 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if defined?(Chef::Deprecated::Base)
+  class Chef
+    class Deprecated
+      class ChefSugar < Base
+        def id
+          28
+        end
+        def target
+          "chef_sugar.html"
+        end
+      end
+    end
+  end
+end
+
+class Chef
+  module Sugar
+    module Deprecation
+      if defined?(Chef::Deprecated::Base)
+        def deprecated(message)
+          Chef.deprecated(:chef_sugar, message)
+        end
+      else
+        def deprecated(message)
+          Chef::Log.warn(message)
+        end
+      end
+      extend self
+    end
+  end
+end

--- a/lib/chef/sugar/node.rb
+++ b/lib/chef/sugar/node.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+require_relative "deprecation"
+
 class Chef
   class Node
     class AttributeDoesNotExistError < StandardError
@@ -36,6 +38,7 @@ EOH
     # @return [Boolean]
     #
     def in?(environment)
+      Chef::Sugar::Deprecation.deprecated "the chef-sugar node.in? method is deprecated"
       environment === chef_environment
     end
 
@@ -49,6 +52,7 @@ EOH
     # @see [Node#deep_fetch!]
     #
     def deep_fetch(*keys)
+      Chef::Sugar::Deprecation.deprecated "the chef-sugar deep_fetch method is deprecated and should be replaced by node.read"
       deep_fetch!(*keys)
     rescue NoMethodError, AttributeDoesNotExistError
       nil
@@ -71,6 +75,7 @@ EOH
     # @return [Object]
     #
     def deep_fetch!(*keys)
+      Chef::Sugar::Deprecation.deprecated "the chef-sugar deep_fetch method is deprecated and should be replaced by node.read!"
       keys.map!(&:to_s)
 
       keys.inject(attributes.to_hash) do |hash, key|
@@ -133,6 +138,7 @@ EOH
     #   to prevent accidential method chaining if the block isn't closed
     #
     def namespace(*args, &block)
+      Chef::Sugar::Deprecation.deprecated "the chef-sugar attribute namespace setting is deprecated, please use traditional chef attribute notation"
       @namespace_options = namespace_options.merge(args.last.is_a?(Hash) ? args.pop : {})
 
       keys = args.map(&:to_s)


### PR DESCRIPTION
This will not be pulled into core chef.  The conventional
chef node attributes API should be used instead.

- The `#in?` helper is dropped as being too trivial

- The deep fetch API was implemented ages ago in `node.read[!]`

- The namespace API will not be accepted into core due to the
  utilization of method_missing.
