### PR TITLE
Get the tests green

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,12 @@ group :debug do
 end
 
 group :test do
-  gem "chefspec", "~> 7.4.0" # supports Chef 13+ aka ruby 2.3+
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5")
+    gem "chefspec", "~> 7.4.0" # supports Chef 13+ aka ruby 2.3+
+    gem "chef", "~> 13" # also needed to support Ruby 2.3
+  else
+    gem "chefspec"
+  end
   gem "rake"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,11 @@ group :debug do
 end
 
 group :test do
-  gem "chefspec"
-  gem "kitchen-vagrant"
+  gem "chefspec", "~> 7.4.0" # supports Chef 13+ aka ruby 2.3+
   gem "rake"
+end
+
+group :kitchen do
+  gem "kitchen-vagrant"
   gem "test-kitchen"
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Chef Sugar
 
 [![Gem Version](http://img.shields.io/gem/v/chef-sugar.svg?style=flat-square)][gem]
+[![Build status](https://badge.buildkite.com/f44140e4898b4935bfc3bba523efc2a7592d7c9a1bae3faf5c.svg?branch=master)](https://buildkite.com/chef-oss/chef-chef-sugar-master-verify)
 
 Chef Sugar is a Gem & Chef Recipe that includes series of helpful syntactic sugars on top of the Chef core and other resources to make a cleaner, more lean recipe DSL, enforce DRY principles, and make writing Chef recipes an awesome and fun experience!
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-require 'bundler/gem_tasks'
-
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new do |t|
   t.rspec_opts = [


### PR DESCRIPTION
Remove the gem tasks from the Rakefile
Move kitchen gems to their own group
Require an older chefspec that works on more Ruby releases

Signed-off-by: Tim Smith <tsmith@chef.io>