### PR TITLE
Don't fail if Chef::VERSION isn't defined

### DIFF
--- a/lib/chef/sugar/architecture.rb
+++ b/lib/chef/sugar/architecture.rb
@@ -20,7 +20,7 @@ class Chef
       extend self
 
       # these helpers have been moved to core-chef
-      unless Gem::Requirement.new(">= 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
+      if !defined?(Chef::VERSION) || Gem::Requirement.new("< 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
         #
         # Determine if the current architecture is 64-bit
         #
@@ -136,7 +136,7 @@ class Chef
     end
 
     module DSL
-      unless Gem::Requirement.new(">= 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
+      if !defined?(Chef::VERSION) || Gem::Requirement.new("< 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
         # @see Chef::Sugar::Architecture#_64_bit?
         def _64_bit?; Chef::Sugar::Architecture._64_bit?(node); end
 

--- a/lib/chef/sugar/docker.rb
+++ b/lib/chef/sugar/docker.rb
@@ -20,7 +20,7 @@ class Chef
       extend self
 
       # these helpers have been moved to core chef
-      unless Gem::Requirement.new(">= 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
+      if !defined?(Chef::VERSION) || Gem::Requirement.new("< 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
         #
         # Returns true if the current node is a docker container.
         #
@@ -36,7 +36,7 @@ class Chef
     end
 
     module DSL
-      unless Gem::Requirement.new(">= 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
+      if !defined?(Chef::VERSION) || Gem::Requirement.new("< 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
         # @see Chef::Sugar::Docker#docker?
         def docker?; Chef::Sugar::Docker.docker?(node); end
       end

--- a/lib/chef/sugar/kitchen.rb
+++ b/lib/chef/sugar/kitchen.rb
@@ -20,7 +20,7 @@ class Chef
       extend self
 
       # these helpers have been moved to core-chef
-      unless Gem::Requirement.new(">= 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
+      if !defined?(Chef::VERSION) || Gem::Requirement.new("< 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
         #
         # Returns true if the current node is provisioned by Test Kitchen.
         #
@@ -36,7 +36,7 @@ class Chef
     end
 
     module DSL
-      unless Gem::Requirement.new(">= 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
+      if !defined?(Chef::VERSION) || Gem::Requirement.new("< 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
         # @see Chef::Sugar::Kitchen#kitchen?
         def kitchen?; Chef::Sugar::Kitchen.kitchen?(node); end
       end

--- a/lib/chef/sugar/platform.rb
+++ b/lib/chef/sugar/platform.rb
@@ -122,7 +122,7 @@ class Chef
       end
 
       # these helpers have been moved to core chef
-      unless Gem::Requirement.new(">= 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
+      if !defined?(Chef::VERSION) || Gem::Requirement.new("< 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
         #
         # Determine if the current node is linux mint.
         #

--- a/lib/chef/sugar/platform_family.rb
+++ b/lib/chef/sugar/platform_family.rb
@@ -20,7 +20,7 @@ class Chef
       extend self
 
       # these helpers have been moved to core chef
-      unless Gem::Requirement.new(">= 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
+      if !defined?(Chef::VERSION) || Gem::Requirement.new("< 15.4.70").satisfied_by?(Gem::Version.new(Chef::VERSION))
 
         #
         # Determine if the current node is a member of the arch family.


### PR DESCRIPTION
this allows chef-sugar to continue to be used with omnibus
