### PR TITLE
Only require libs if we haven't already loaded them

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -2,43 +2,15 @@
 #
 # This script runs a passed in command, but first setups up the bundler caching on the repo
 
-set -e
+set -ue
 
 export USER="root"
+export LANG=C.UTF-8 LANGUAGE=C.UTF-8
 
-# make sure we have the aws cli
-apt-get update -y
-apt-get install awscli -y
+echo "--- bundle install"
 
-# grab the s3 bundler if it's there and use it for all operations in bundler
-echo "Fetching bundle cache archive from s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz"
-aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz" bundle.tar.gz || echo 'Could not pull the bundler archive from s3 for caching. Builds may be slower than usual as all gems will have to install.'
-aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" bundle.sha256 || echo "Could not pull the sha256 hash of the vendor/bundle directory from s3. Without this we will compress and upload the bundler archive to S3 even if it hasn't changed"
-
-echo "Restoring the bundle cache archive to vendor/bundle"
-if [ -f bundle.tar.gz ]; then
-  tar -xzf bundle.tar.gz
-fi
 bundle config --local path vendor/bundle
+bundle install --jobs=7 --retry=3 --without docs debug kitchen
 
-bundle install --jobs=7 --retry=3
-bundle exec $1
-
-if [[ -f bundle.tar.gz && -f bundle.sha256  ]]; then # dont' check the sha if we're missing either file
-  if shasum --check bundle.sha256 --status; then # if the the sha matches we're done
-    echo "Bundled gems have not changed. Skipping upload to s3"
-    exit
-  fi
-fi
-
-echo "Generating sha256 hash file of the vendor/bundle directory to ship to s3"
-shasum -a 256 vendor/bundle > bundle.sha256
-
-echo "Creating the tar.gz to of the vendor/bundle directory to ship to s3"
-tar -czf bundle.tar.gz vendor/
-
-echo "Uploading the tar.gz of the vendor/bundle directory to s3"
-aws s3 cp bundle.tar.gz "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'
-
-echo "Uploading the sha256 hash of the vendor/bundle directory to s3"
-aws s3 cp bundle.sha256 "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'
+echo "+++ bundle exec task"
+bundle exec $@

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,3 +1,14 @@
+---
+expeditor:
+  cached_folders:
+    - vendor
+  defaults:
+    buildkite:
+      retry:
+        automatic:
+          limit: 1
+      timeout_in_minutes: 30
+
 steps:
 
 - label: run-specs-ruby-2.3
@@ -31,3 +42,21 @@ steps:
     executor:
       docker:
         image: ruby:2.6-buster
+
+- label: run-specs-ruby-2.7
+  command:
+    - .expeditor/run_linux_tests.sh "rake"
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.7-buster
+
+- label: run-specs-windows
+  command:
+    - bundle config --local path vendor/bundle
+    - bundle install --jobs=7 --retry=3 --without=debug
+    - bundle exec rake spec
+  expeditor:
+    executor:
+      docker:
+        host_os: windows

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,18 @@ gemspec name: "chef-sugar"
 
 group :debug do
   gem "pry"
-  gem "pry-byebug"
-  gem "pry-stack_explorer"
+  gem "pry-byebug" unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4")
+  gem "pry-stack_explorer", "~> 0.4.0" # pin until we drop ruby < 2.6
 end
 
 group :test do
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5")
     gem "chefspec", "~> 7.4.0" # supports Chef 13+ aka ruby 2.3+
     gem "chef", "~> 13" # also needed to support Ruby 2.3
+  elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
+    gem "chefspec"
+    gem "chef-zero", "~> 14"
+    gem "chef", "~> 15" # also needed to support Ruby 2.3
   else
     gem "chefspec"
   end
@@ -18,11 +22,13 @@ group :test do
     gem "rubyzip", "< 2"
   else
     gem "rubyzip"
-   end
+  end
   gem "rake"
+  gem "rspec"
 end
 
 group :kitchen do
   gem "kitchen-vagrant"
+  gem "license-acceptance", "~> 1.0" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4")
   gem "test-kitchen"
 end

--- a/lib/chef/sugar/shell.rb
+++ b/lib/chef/sugar/shell.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-require 'mixlib/shellout'
-require 'pathname'
+require 'mixlib/shellout' unless defined?(Mixlib::ShellOut)
+require 'pathname' unless defined?(Pathname)
 
 class Chef
   module Sugar


### PR DESCRIPTION
Rubygems is very slow at requiring files so only do it if we really need
to.

Signed-off-by: Tim Smith <tsmith@chef.io>