### PR TITLE
Don't define which helper on Chef 16+ to avoid conflicts

### DIFF
--- a/lib/chef/sugar/shell.rb
+++ b/lib/chef/sugar/shell.rb
@@ -22,7 +22,7 @@ class Chef
     module Shell
       extend self
 
-      # this helpers have been moved to core chef
+      # this helper has been moved to core chef
       if !defined?(Chef::VERSION) || Gem::Requirement.new("< 16.0.257").satisfied_by?(Gem::Version.new(Chef::VERSION))
         #
         # Finds a command in $PATH

--- a/lib/chef/sugar/shell.rb
+++ b/lib/chef/sugar/shell.rb
@@ -22,26 +22,29 @@ class Chef
     module Shell
       extend self
 
-      #
-      # Finds a command in $PATH
-      #
-      # @param [String] cmd
-      #   the command to find
-      #
-      # @return [String, nil]
-      #
-      def which(cmd)
-        if Pathname.new(cmd).absolute?
-          File.executable?(cmd) ? cmd : nil
-        else
-          paths = ENV['PATH'].split(::File::PATH_SEPARATOR) + %w(/bin /usr/bin /sbin /usr/sbin)
+      # this helpers have been moved to core chef
+      if !defined?(Chef::VERSION) || Gem::Requirement.new("< 16.0.257").satisfied_by?(Gem::Version.new(Chef::VERSION))
+        #
+        # Finds a command in $PATH
+        #
+        # @param [String] cmd
+        #   the command to find
+        #
+        # @return [String, nil]
+        #
+        def which(cmd)
+          if Pathname.new(cmd).absolute?
+            File.executable?(cmd) ? cmd : nil
+          else
+            paths = ENV['PATH'].split(::File::PATH_SEPARATOR) + %w(/bin /usr/bin /sbin /usr/sbin)
 
-          paths.each do |path|
-            possible = File.join(path, cmd)
-            return possible if File.executable?(possible)
+            paths.each do |path|
+              possible = File.join(path, cmd)
+              return possible if File.executable?(possible)
+            end
+
+            nil
           end
-
-          nil
         end
       end
 
@@ -128,8 +131,11 @@ class Chef
     end
 
     module DSL
-      # @see Chef::Sugar::Shell#which
-      def which(cmd); Chef::Sugar::Shell.which(cmd); end
+      # this helpers have been moved to core chef
+      if !defined?(Chef::VERSION) || Gem::Requirement.new("< 16.0.257").satisfied_by?(Gem::Version.new(Chef::VERSION))
+        # @see Chef::Sugar::Shell#which
+        def which(cmd); Chef::Sugar::Shell.which(cmd); end
+      end
 
       # @see Chef::Sugar::Shell#dev_null
       def dev_null; Chef::Sugar::Shell.dev_null(node); end

--- a/lib/chef/sugar/shell.rb
+++ b/lib/chef/sugar/shell.rb
@@ -131,7 +131,7 @@ class Chef
     end
 
     module DSL
-      # this helpers have been moved to core chef
+      # this helper has been moved to core chef
       if !defined?(Chef::VERSION) || Gem::Requirement.new("< 16.0.257").satisfied_by?(Gem::Version.new(Chef::VERSION))
         # @see Chef::Sugar::Shell#which
         def which(cmd); Chef::Sugar::Shell.which(cmd); end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rspec'
 require 'chefspec'
 require 'chef/sugar'
+require 'chef/version'
 
 require_relative 'support/shared_examples'
 
@@ -22,4 +23,6 @@ RSpec.configure do |config|
 
   # ChefSpec configuration
   config.log_level = :fatal
+
+  config.filter_run_excluding pre_chef16_only: true if Gem::Requirement.new(">= 16.0.257").satisfied_by?(Gem::Version.new(Chef::VERSION))
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,5 +24,5 @@ RSpec.configure do |config|
   # ChefSpec configuration
   config.log_level = :fatal
 
-  config.filter_run_excluding pre_chef16_only: true if Gem::Requirement.new(">= 16.0.257").satisfied_by?(Gem::Version.new(Chef::VERSION))
+  config.filter_run_excluding pre_chef16_only: Gem::Requirement.new(">= 16.0.257").satisfied_by?(Gem::Version.new(Chef::VERSION))
 end

--- a/spec/unit/chef/sugar/shell_spec.rb
+++ b/spec/unit/chef/sugar/shell_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Chef::Sugar::Shell do
-  describe '#which' do
+  describe '#which', :pre_chef16_only do
     it 'returns the first executable matching the command' do
       allow(File).to receive(:executable?).and_return(false)
       allow(File).to receive(:executable?).with('/usr/bin/mongo').and_return(true)
@@ -46,7 +46,7 @@ describe Chef::Sugar::Shell do
     end
 
     it 'returns false if the given binary does not exist' do
-      allow(File).to receive(:executable?).and_return(false)
+      allow(described_class).to receive(:which).with('node').and_return(nil)
       expect(described_class.installed?('node')).to be false
     end
   end


### PR DESCRIPTION
We have our own which helper in the DSL now, which takes 2 args. This
helper is getting injected over it, which works most of the time (not as
well), but doesn't work when someone passes additional args. This breaks
gem_package and probably some other things in the ecosystem. We need to
continue to support chef-sugar being installed on a modern chef-client
release since that's necessary for client upgrades, but we should not
allow the injection of a legacy helper over the built-in.

Signed-off-by: Tim Smith <tsmith@chef.io>